### PR TITLE
Adding meltano integration test

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,10 @@ jobs:
       TAP_STRAVA_REFRESH_TOKEN: ${{ secrets.TAP_STRAVA_REFRESH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: pip
       - name: Install pipx
         run: python -m pip install pipx
       - name: Install meltano

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,27 @@
+name: Integration tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  meltano:
+    runs-on: ubuntu-latest
+    env:
+      TAP_STRAVA_CLIENT_ID: ${{ secrets.TAP_STRAVA_CLIENT_ID }}
+      TAP_STRAVA_CLIENT_SECRET: ${{ secrets.TAP_STRAVA_CLIENT_SECRET }}
+      TAP_STRAVA_REFRESH_TOKEN: ${{ secrets.TAP_STRAVA_REFRESH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Install pipx
+        run: python -m pip install pipx
+      - name: Install meltano
+        run: pipx install meltano
+      - name: Run meltano
+        working-directory: .github/workflows/meltano
+        run: |
+          meltano install --clean
+          meltano elt tap-strava target-jsonl
+

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          cache: pip
       - name: Install pipx
         run: python -m pip install pipx
       - name: Install meltano

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -25,5 +25,5 @@ jobs:
         working-directory: .github/workflows/meltano
         run: |
           meltano install --clean
-          meltano elt tap-strava target-jsonl
+          meltano --log-level=debug elt tap-strava target-jsonl
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
       - name: Install the dependency manager
         run: pip install poetry
       - name: Install the project dependencies

--- a/.github/workflows/meltano/.gitignore
+++ b/.github/workflows/meltano/.gitignore
@@ -1,2 +1,3 @@
 plugins/
 .meltano
+output/

--- a/.github/workflows/meltano/.gitignore
+++ b/.github/workflows/meltano/.gitignore
@@ -1,0 +1,2 @@
+plugins/
+.meltano

--- a/.github/workflows/meltano/meltano.yml
+++ b/.github/workflows/meltano/meltano.yml
@@ -1,0 +1,32 @@
+version: 1
+default_environment: dev
+environments:
+- name: dev
+- name: staging
+- name: prod
+
+plugins:
+
+  extractors:
+  - name: tap-strava
+    namespace: tap_strava
+    pip_url: -e ../../../
+    executable: tap-strava
+    capabilities:
+    - catalog
+    - discover
+    - properties
+    - state
+    settings:
+    - name: client_id
+    - name: client_secret
+    - name: refresh_token
+    config:
+      client_id: ${TAP_STRAVA_CLIENT_ID}
+      client_secret: ${TAP_STRAVA_CLIENT_SECRET}
+      refresh_token: ${TAP_STRAVA_REFRESH_TOKEN}
+  loaders:
+  - name: target-jsonl
+    config:
+      destintation_path: /tmp/strava-sync.json
+project_id: a334dafa-6520-48f2-8370-a2d83241342b

--- a/.github/workflows/meltano/meltano.yml
+++ b/.github/workflows/meltano/meltano.yml
@@ -21,10 +21,14 @@ plugins:
     - name: client_id
     - name: client_secret
     - name: refresh_token
+    - name: start_date
+    - name: end_date
     config:
       client_id: ${TAP_STRAVA_CLIENT_ID}
       client_secret: ${TAP_STRAVA_CLIENT_SECRET}
       refresh_token: ${TAP_STRAVA_REFRESH_TOKEN}
+      start_date: 2022-11-01
+      end_date: 2022-11-15
   loaders:
   - name: target-jsonl
     config:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Unit tests
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
       - name: Install dependency manager
         run: pip install poetry
       - name: Install project dependencies

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a singer tap for the [Strava API](https://developers.strava.com/docs/) b
 
 
 [![Unit Tests](https://github.com/dluftspring/tap-strava/actions/workflows/test.yaml/badge.svg)](https://github.com/dluftspring/tap-strava/actions/workflows/test.yaml)
+[![Integration tests](https://github.com/dluftspring/tap-strava/actions/workflows/integration_tests.yml/badge.svg)](https://github.com/dluftspring/tap-strava/actions/workflows/integration_tests.yml)
 ## Quickstart
 
 Install poetry for your OS and then run:
@@ -64,6 +65,10 @@ You'll need to supply three config parameters
 | client_id | Unique client identifier for your strava application | string (required) | TAP_STRAVA_CLIENT_ID |
 | client_secret | Unique secret key for your strava application | string (required) | TAP_STRAVA_CLIENT_SECRET |
 | refresh_token | Scoped refresh token obtained from the Strava Oauth flow | string (required) | TAP_STRAVA_REFRESH_TOKEN |
+| start_date | Date from which to start syncing data in YYYY-MM-DD format | Date (optional) | TAP_STRAVA_START_DATE |
+| end_date | Date at which to stop syncing data in YYYY-MM-DD format | Date (optional) | TAP_STRAVA_END_DATE |
+
+Note that the usage of start and end date parameters will override the default behaviour of syncing based on incremental state
 
 You can set these parameters as environment variables or by specifying a json configuration file with the following info
 
@@ -72,7 +77,9 @@ You can set these parameters as environment variables or by specifying a json co
   {
     "client_id": "<YOUR CLIENT ID>",
     "client_secret": "<YOUR CLIENT SECRET>",
-    "refresh_token": "<YOUR REFRESH TOKEN>"
+    "refresh_token": "<YOUR REFRESH TOKEN>",
+    "start_date": "2021-01-01",
+    "end_date": "2021-01-31"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a singer tap for the [Strava API](https://developers.strava.com/docs/) built using Meltano's [singer SDK](https://github.com/meltano/sdk).
 
+
+[![Unit Tests](https://github.com/dluftspring/tap-strava/actions/workflows/test.yaml/badge.svg)](https://github.com/dluftspring/tap-strava/actions/workflows/test.yaml)
 ## Quickstart
 
 Install poetry for your OS and then run:

--- a/tap_strava/client.py
+++ b/tap_strava/client.py
@@ -59,4 +59,15 @@ class stravaStream(RESTStream):
             "page": next_page_token,
         }
 
+        if self.config['start_date']:
+            params['after'] = self._datetime_to_epoch_time(self.config['start_date'])
+        if self.config['end_date']:
+            params['before'] = self._datetime_to_epoch_time(self.config['end_date'])
+
         return params
+
+    def _datetime_to_epoch_time(self, dt: str) -> int:
+        """
+        Converts a datetime string to epoch time
+        """
+        return datetime.datetime.strptime(dt, "%Y-%m-%d").strftime('%s')

--- a/tap_strava/client.py
+++ b/tap_strava/client.py
@@ -59,10 +59,10 @@ class stravaStream(RESTStream):
             "page": next_page_token,
         }
 
-        if self.config['start_date']:
-            params['after'] = self._datetime_to_epoch_time(self.config['start_date'])
-        if self.config['end_date']:
-            params['before'] = self._datetime_to_epoch_time(self.config['end_date'])
+        if self.config["start_date"]:
+            params["after"] = self._datetime_to_epoch_time(self.config["start_date"])
+        if self.config["end_date"]:
+            params["before"] = self._datetime_to_epoch_time(self.config["end_date"])
 
         return params
 
@@ -70,4 +70,4 @@ class stravaStream(RESTStream):
         """
         Converts a datetime string to epoch time
         """
-        return datetime.datetime.strptime(dt, "%Y-%m-%d").strftime('%s')
+        return datetime.datetime.strptime(dt, "%Y-%m-%d").strftime("%s")

--- a/tap_strava/schemas/activities.json
+++ b/tap_strava/schemas/activities.json
@@ -179,7 +179,10 @@
             "description": "Whether this activity is flagged"
         },
         "workout_type": {
-            "type": "integer",
+            "type": [
+                "integer",
+                "null"
+            ],
             "description": "The activity's workout type"
         },
         "upload_id_str": {

--- a/tap_strava/tap.py
+++ b/tap_strava/tap.py
@@ -35,6 +35,18 @@ class tapStrava(Tap):
             required=True,
             description="Scoped refresh token obtained from the Strava oauth flow",
         ),
+        th.Property(
+            "start_date",
+            th.DateTimeType,
+            required=False,
+            description="Start date for the data sync in YYYY-MM-DD format",
+        ),
+        th.Property(
+            "end_date",
+            th.DateTimeType,
+            required=False,
+            description="End date for the data sync in YYYY-MM-DD format",
+        )
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:

--- a/tap_strava/tap.py
+++ b/tap_strava/tap.py
@@ -46,7 +46,7 @@ class tapStrava(Tap):
             th.DateTimeType,
             required=False,
             description="End date for the data sync in YYYY-MM-DD format",
-        )
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:

--- a/tap_strava/tests/test_core.py
+++ b/tap_strava/tests/test_core.py
@@ -30,6 +30,10 @@ def set_sample_config(config_path: Path) -> Dict[str, Any]:
         or file_config_params.get("client_secret", None),
         "refresh_token": os.getenv("TAP_STRAVA_REFRESH_TOKEN")
         or file_config_params.get("refresh_token", None),
+        "start_date": os.getenv("TAP_STRAVA_START_DATE")
+        or file_config_params.get("start_date", None),
+        "end_date": os.getenv("TAP_STRAVA_END_DATE")
+        or file_config_params.get("end_date", None),
     }
 
     return config_to_test


### PR DESCRIPTION
## Description & motivation

Singer taps are most often run from within meltano projects. `meltano elt` is very opinionated about nullability in the jsonschema. This adds an integration test that will catch meltano failures

### This is a...

- [ ] :tada: New feature
- [ ] :beetle: Bug fix
- [ ] :gear: Refactor
- [x] :recycle: Housekeeping
  
## Screenshots

## Open questions

## How to test
