### PR TITLE
Better handling when optional configs aren't passed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "dbt.queryLimit": 500
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dbt.queryLimit": 500
+}

--- a/tap_strava/client.py
+++ b/tap_strava/client.py
@@ -59,10 +59,13 @@ class stravaStream(RESTStream):
             "page": next_page_token,
         }
 
-        if self.config["start_date"]:
-            params["after"] = self._datetime_to_epoch_time(self.config["start_date"])
-        if self.config["end_date"]:
-            params["before"] = self._datetime_to_epoch_time(self.config["end_date"])
+        start_date = self.config.get("start_date", None)
+        end_date = self.config.get("end_date", None)
+
+        if start_date:
+            params["after"] = self._datetime_to_epoch_time(start_date)
+        if end_date:
+            params["before"] = self._datetime_to_epoch_time(end_date)
 
         return params
 


### PR DESCRIPTION
## Description & motivation

Tap is throwing a `KeyError` when the client tries to access empty configs for optional parameters start_date and end_date. This should fix the issue

### This is a...

- [ ] :tada: New feature
- [x] :beetle: Bug fix
- [ ] :gear: Refactor
- [ ] :recycle: Housekeeping
  
## Screenshots

## Open questions

## How to test
