### PR TITLE
Handle Rate Limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ This is a singer tap for the [Strava API](https://developers.strava.com/docs/) b
 [![Integration tests](https://github.com/dluftspring/tap-strava/actions/workflows/integration_tests.yml/badge.svg)](https://github.com/dluftspring/tap-strava/actions/workflows/integration_tests.yml)
 ## Quickstart
 
-Install poetry for your OS and then run:
+Install the repo from source:
 
 ```bash
-poetry install
+pip install git+https://github.com/dluftspring/tap-strava.git
 ```
 
 To run the tap:
 
 ```bash
-poetry run tap-strava --config <path-to-your-config.json> --test
+tap-strava --config <path-to-your-config.json> --test
 ```
 
 This should validate the tap by trying to sync a single record from the available streams

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-strava"
-version = "0.2.0"
+version = "0.3.0"
 description = "Singer tap for the strava API"
 authors = ["dluftspring <daniel.luftspring@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Description & motivation

Solves #5 by implementing throtlling. When a user hits their 15 minute rate limit the tap will go to sleep for 15 minutes in the case of a daily rate limit overage the tap will error and exit. I'm assuming that it's reasonable for data syncing pipelines to want to continue when the latency is 15 minutes but not want to continue if they have to wait for a full day.

### This is a...

- [x] :tada: New feature
- [ ] :beetle: Bug fix
- [ ] :gear: Refactor
- [ ] :recycle: Housekeeping
  
## Screenshots

## Open questions

Is it spammy to add log output to every request alerting the user to how much of the rate limit they've actively used?

## How to test
