### PR TITLE
Add incremental sync support for all streams

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG PYTHON_VERSION=3
+
+FROM mcr.microsoft.com/devcontainers/python:${PYTHON_VERSION}-bullseye
+
+RUN pipx install --system-site-packages \
+    --pip-args '--no-cache-dir --force-reinstall' \
+    ruff;
+
+RUN pipx install --system-site-packages \
+    --pip-args '--no-cache-dir --force-reinstall' \
+    poetry;

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+    "name": "tap-strava Devcontainer",
+    "build": {
+      "dockerfile": "./Dockerfile",
+      "args": { "PYTHON_VERSION": "3.10" }
+    },
+
+    "mounts": ["source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind"],
+
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+          // Set *default* container specific settings.json values on container create.
+          "settings": {
+            "emeraldwalk.runonsave": {
+              "commands": [
+                { "match": "\\.py", "cmd": "ruff ${file} --fix" }
+              ]
+            },
+            "terminal.integrated.defaultProfile.linux": "zsh",
+            "python.linting.enabled": true,
+            "python.formatting.provider": "none",
+            "python.linting.banditEnabled": true,
+            "python.linting.mypyEnabled": true,
+            "python.linting.pydocstyleEnabled": true,
+            "python.analysis.typeCheckingMode": "basic",
+            "[python]": {
+              "editor.defaultFormatter": "ms-python.black-formatter",
+              "editor.formatOnSave": true,
+              "editor.codeActionsOnSave": {
+                "source.organizeImports": true,
+                "source.fixAll": true
+              }
+            },
+            "black-formatter.importStrategy": "fromEnvironment",
+            "ruff.importStrategy": "fromEnvironment",
+            "ruff.path": ["/usr/local/py-utils/bin/ruff"]
+          },
+
+          // Add the IDs of extensions you want installed when the container is created.
+          "extensions": [
+            "ms-python.python",
+            "ms-python.black-formatter",
+            "charliermarsh.ruff",
+            "ms-python.vscode-pylance",
+            "bungcip.better-toml",
+            "emeraldwalk.runonsave",
+            "EditorConfig.EditorConfig",
+            "eamodio.gitlens",
+            "github.vscode-pull-request-github",
+            "visualstudioexptteam.vscodeintellicode"
+          ]
+        }
+      },
+
+      "postCreateCommand": "poetry install",
+      "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This should validate the tap by trying to sync a single record from the availabl
 
 ### For developers
 
+If you're using this tap with vscode you can use a devcontainer to get up and running quickly. If you aren't then follow the additional steps below.
+
 ```bash
 poetry install
 ```

--- a/tap_strava/client.py
+++ b/tap_strava/client.py
@@ -67,7 +67,9 @@ class StravaStream(RESTStream):
             start_value = self.get_starting_replication_key_value(context)
             self.logger.debug(f"Your starting replication value is: {start_value}")
             if start_value:
-                params["after"] = self._datetime_to_epoch_time(start_value, format='%Y-%m-%dT%H:%M:%SZ')
+                params["after"] = self._datetime_to_epoch_time(
+                    start_value, format="%Y-%m-%dT%H:%M:%SZ"
+                )
         if start_date:
             params["after"] = self._datetime_to_epoch_time(start_date)
         if end_date:
@@ -114,7 +116,7 @@ class StravaStream(RESTStream):
             msg = self.response_error_message(response)
             raise FatalAPIError(msg)
 
-    def _datetime_to_epoch_time(self, dt: str, format='%Y-%m-%d') -> int:
+    def _datetime_to_epoch_time(self, dt: str, format="%Y-%m-%d") -> int:
         """
         Converts a datetime string to epoch time
         """

--- a/tap_strava/client.py
+++ b/tap_strava/client.py
@@ -1,6 +1,7 @@
 import time
 import datetime
 import requests
+from dateutil import parser as date_parser
 from typing import Dict, Optional, Any, Union
 from singer_sdk.exceptions import RetriableAPIError, FatalAPIError
 
@@ -68,7 +69,7 @@ class StravaStream(RESTStream):
             self.logger.debug(f"Your starting replication value is: {start_value}")
             if start_value:
                 params["after"] = self._datetime_to_epoch_time(
-                    start_value, format="%Y-%m-%dT%H:%M:%SZ"
+                    start_value
                 )
         if start_date:
             params["after"] = self._datetime_to_epoch_time(start_date)
@@ -116,10 +117,10 @@ class StravaStream(RESTStream):
             msg = self.response_error_message(response)
             raise FatalAPIError(msg)
 
-    def _datetime_to_epoch_time(self, dt: str, format="%Y-%m-%d") -> int:
+    def _datetime_to_epoch_time(self, dt: str) -> int:
         """
         Converts a datetime string to epoch time
         """
 
         self.logger.debug(f"Trying to convert {dt} to epoch time")
-        return datetime.datetime.strptime(dt, format).strftime("%s")
+        return date_parser.parse(dt).strftime("%s")

--- a/tap_strava/client.py
+++ b/tap_strava/client.py
@@ -68,9 +68,7 @@ class StravaStream(RESTStream):
             start_value = self.get_starting_replication_key_value(context)
             self.logger.debug(f"Your starting replication value is: {start_value}")
             if start_value:
-                params["after"] = self._datetime_to_epoch_time(
-                    start_value
-                )
+                params["after"] = self._datetime_to_epoch_time(start_value)
         if start_date:
             params["after"] = self._datetime_to_epoch_time(start_date)
         if end_date:

--- a/tap_strava/schemas/activity_comments.json
+++ b/tap_strava/schemas/activity_comments.json
@@ -39,7 +39,10 @@
             "description": "The time at which this comment was created."
         },
         "cursor": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "description": "The cursor used to paginate through the list of comments"
         }
     }


### PR DESCRIPTION
## Description & motivation

This PR makes each stream with an `after` query parameter filterable according to its state. Meaning if you run an extraction pipeline up to Nov 1 it will resume after Nov 1 and update its state.

I've also added a basic devcontainer setup to make contributing and maintaining a bit easier.

### This is a...

- [x] :tada: New feature
- [ ] :beetle: Bug fix
- [ ] :gear: Refactor
- [ ] :recycle: Housekeeping
  
## Screenshots

## Open questions

## How to test
